### PR TITLE
Fixed message dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,10 @@ add_library(usv_gazebo_thrust_plugin
   src/usv_gazebo_thrust_plugin.cpp
   )
 
+add_dependencies(usv_gazebo_thrust_plugin
+  usv_gazebo_plugins_generate_messages_cpp
+)
+
 target_link_libraries(usv_gazebo_thrust_plugin
   ${catkin_LIBRARIES}
   ${GAZEBO_LIBRARIES}


### PR DESCRIPTION
Added explicit message dependency. Without it my catkin make dies with error
```
usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_thrust_plugin.h:36:41: fatal error: usv_gazebo_plugins/UsvDrive.h: No such file or directory
```